### PR TITLE
macOS 10.x (and Mac OS X) uses LF as end-of-line.

### DIFF
--- a/easy_abc.py
+++ b/easy_abc.py
@@ -5451,7 +5451,7 @@ class MainFrame(wx.Frame):
             return
 
         if wx.Platform == "__WXMAC__":
-            text = text.replace('\r\n', '\r')
+            text = text.replace('\r\n', '\n')
         else:
             text = re.sub('\r+', '\r', text)
             if not '\n' in text:


### PR DESCRIPTION
It is 20 years now since Apple starts using LF(aka '\n') as end-of-line
instead of formerly used CR (aka '\r').