### PR TITLE
fix MIDI input with latest wx and Python 3

### DIFF
--- a/easy_abc.py
+++ b/easy_abc.py
@@ -1793,8 +1793,10 @@ class RecordThread(threading.Thread):
         gmidi_in.append(self.midi_out)
         self.notes = []
         self.is_running = False
-        self.tick1 = wx.Sound(os.path.join(cwd, 'sound', 'tick1.wav'))
-        self.tick2 = wx.Sound(os.path.join(cwd, 'sound', 'tick2.wav'))
+
+        import wx.adv
+        self.tick1 = wx.adv.Sound(os.path.join(cwd, 'sound', 'tick1.wav'))
+        self.tick2 = wx.adv.Sound(os.path.join(cwd, 'sound', 'tick2.wav'))
 
     def timedelta_microseconds(self, td):
         return td.seconds*1000000 + td.microseconds

--- a/midi2abc.py
+++ b/midi2abc.py
@@ -153,7 +153,7 @@ def note_to_string(note, duration, default_len, key_accidentals, cur_accidentals
         -7: '=C _D =D _E _F =F _G =G _A __B _B _C', }
 
     scale = accidentals_to_scale[n_accidentals].split()
-    notes = [n.lower().translate(None, '_=^')
+    notes = [n.lower().translate(str.maketrans('', '', '_=^'))
              for n in scale]   # for semitone: the name of the note
     # for semitone: 0 if white key, -1 or -2 if flat, 1 or 2 if sharp
     accidentals = [n.count('^') - n.count('_') for n in scale]


### PR DESCRIPTION
This is my latest attempt to get MIDI input working in EasyABC (on Windows 10). When I ran from source code I got this error:

```
File` ".\easy_abc.py", line 1796, in __init__
        self.tick1 = wx.Sound(os.path.join(cwd, 'sound', 'tick1.wav'))
    AttributeError: module 'wx' has no attribute 'Sound'
```

It looks like the wx framework the wx.Sound module was moved to wx.adv.Sound.

I also got an error about the Python `translate` function, which needed a change to work with Python 3.

(I don't know if there are people who need to be able to run EasyABC with older versions of wx or Python, and whether these fixed would break things for them.)

Finally there are two sound files (tick1.wav and tick2.wav) that are used to make a metronome, these weren't included in the sources but I was able to copy them over from an installed version of EasyABC.

The pull request has the 2 code changes; I didn't include the wav files.