### PR TITLE
Fixup svg_stroke=='none' under MacOS and wxPython >= 4.1

### DIFF
--- a/svgrenderer.py
+++ b/svgrenderer.py
@@ -597,7 +597,7 @@ class SvgRenderer(object):
         if pen is None:
             if svg_stroke == 'none':
                 if WX41:
-                    pen = self.renderer.CreatePen(wx.GraphicsPenInfo())
+                    pen = self.renderer.CreatePen(wx.GraphicsPenInfo(style=wx.PENSTYLE_TRANSPARENT))
                 else:
                     pen = self.renderer.CreatePen(wx.NullPen)
             else:


### PR DESCRIPTION
svgrender uses a pen defined by

    self.renderer.CreatePen(wx.GraphicsPenInfo())

for strokes with svg_stroke=='none' when using wxPython >= 4.1. At least
under MacOS this results in an exception

    wx._core.wxAssertionError: C++ assertion "retval != __null" failed at /Users/robind/projects/bb2/dist-osx-py38/build/ext/wxWidgets/src/osx/carbon/graphics.cpp(116) in wxMacCreateCGColor():

This commit adds `style=wx.PENSTYLE_TRANSPARENT` to the pen definition
which seems to resolve the problem while still resulting in correct output.