### PR TITLE
fix #31 Error importing MIDI file in Python 3.x

### DIFF
--- a/midi/MidiFileParser.py
+++ b/midi/MidiFileParser.py
@@ -44,7 +44,7 @@ class MidiFileParser:
         header_chunk_zise = raw_in.readBew(4)
 
         # check if it is a proper midi file
-        if header_chunk_type != 'MThd':
+        if header_chunk_type != b'MThd':
             raise TypeError("It is not a valid midi file!")
 
         # Header values are at fixed locations, so no reason to be clever


### PR DESCRIPTION
Tested with Python 3.6.4 on Windows 10. It should work under Python 2.x. Added a "b" to indicate a byte string (otherwise Python3 defaults to Unicode). [According to the docs,](https://docs.python.org/2/reference/lexical_analysis.html#string-literals) the "b" prefix is ignored in Python 2.