### PR TITLE
Feature/midi input unicode

### DIFF
--- a/midi/MidiFileParser.py
+++ b/midi/MidiFileParser.py
@@ -44,7 +44,7 @@ class MidiFileParser:
         header_chunk_zise = raw_in.readBew(4)
 
         # check if it is a proper midi file
-        if header_chunk_type != 'MThd':
+        if header_chunk_type != b'MThd':
             raise TypeError("It is not a valid midi file!")
 
         # Header values are at fixed locations, so no reason to be clever

--- a/midi2abc.py
+++ b/midi2abc.py
@@ -30,6 +30,11 @@ import math
 from simple_abc_parser import get_best_key_for_midi_notes, get_accidentals_for_key
 from io import StringIO
 
+PY3 = sys.version_info.major > 2
+if PY3:
+    def unicode(s):
+        return s
+
 num_quarter_notes_per_bar = 3
 bars_per_line = 4
 


### PR DESCRIPTION
Fix an issue with parsing MIDI input (from a file or from an actual device like a MIDI keyboard) that has a "broken rhythm" (i.e. the < or > symbols to created dotted notes) in Python3, which was using the Python 2 `unicode` function. Handle in the same way the code handles the `unicode` function in other files to be compatible with both Python 2 and 3.

Steps to reproduce: 
1. Create a tune with a broken rhythm, e.g.: `C>CCC | C/<C/C3 |]`
2. Export to MIDI.
3. Try to import the MIDI file - you will get an error. Expect to be able to "round trip."

Note: Reproduced with Python 3.6.4 on Windows 10.
