### PR TITLE
Fix determining gs_path on Linux. Fixes #66

### DIFF
--- a/easy_abc.py
+++ b/easy_abc.py
@@ -8368,7 +8368,7 @@ class MainFrame(wx.Frame):
             elif wx.Platform == '__WXGTK__':
                 try:
                     gs_path = subprocess.check_output(["which", "gs"])
-                    settings['gs_path'] = unicode(gs_path[0:-1])
+                    settings['gs_path'] = gs_path[0:-1].decode()
                 except:
                     settings['gs_path'] = ''
             #1.3.6.1 [SS] 2014-01-13


### PR DESCRIPTION
Fixes #66

When running EasyABC for the first time under Linux, it tries to determine the path to gs from the output of `which gs`. However, in python3, it returns a bytestring (eg `b'/usr/bin/gs\n'`). EasyABC is expecting a str.  Simply adding .decode() fixes the issue.

As I read the code, the `unicode()` call is left over from python2 and can be removed.

Tested on Manjaro linux, python3.10.10

Cheers :beers: