### PR TITLE
Fix dialog background color for dark mode support

### DIFF
--- a/abc_assist_panel.py
+++ b/abc_assist_panel.py
@@ -42,22 +42,31 @@ class AbcAssistControl(object):
 
 
 class AbcAssistPanel(wx.Panel):
-    html_header = """\
+    html_header_light = """\
 <!DOCTYPE html>
 <meta charset="utf-8" />
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <html>
 <body>
 """
+    html_header_dark = """\
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<html>
+<body bgcolor="#1e1e1e" text="#e0e0e0" link="#6699ff">
+"""
     html_footer = "</body></html>"
 
-    def __init__(self, parent, editor, cwd, settings):
+    def __init__(self, parent, editor, cwd, settings, is_dark_mode=False):
         wx.Panel.__init__(self, parent, -1)
         if wx.Platform == "__WXMSW__":
             self.SetBackgroundStyle(wx.BG_STYLE_CUSTOM)
 
         self._editor = editor
         self.settings = settings
+        self.is_dark_mode = is_dark_mode
+        self.html_header = self.html_header_dark if is_dark_mode else self.html_header_light
         self.context = None
         self.abc_section = None
         self.elements = AbcStructure.generate_abc_elements(cwd)
@@ -99,6 +108,8 @@ class AbcAssistPanel(wx.Panel):
 
         self.current_html = wx.html.HtmlWindow(panel, -1, style=wx.html.HW_SCROLLBAR_AUTO | wx.html.HW_NO_SELECTION)
         self.current_html.SetFonts('', '', sizes=[font_size, font_size, font_size, h5_h6_size, h3_h4_size, h2_size, h1_size])
+        if self.is_dark_mode:
+            self.current_html.SetBackgroundColour(wx.Colour(30, 30, 30))
 
         panel_sizer.Add(self.current_html, 1, wx.ALL | wx.EXPAND)
         self.current_html.Bind(wx.html.EVT_HTML_LINK_CLICKED, self.on_link_clicked)

--- a/easy_abc.py
+++ b/easy_abc.py
@@ -1596,7 +1596,7 @@ class MusicPrintout(wx.Printout):
         #new versions of abcm2ps adds a suffix 'in' to width and height
         #new versions of abcm2ps adds a suffix 'px' to width and height
         # 1.3.7.3 [JWDJ] use svg renderer to calculate width and height
-        renderer = SvgRenderer(self.can_draw_sharps_and_flats, highlight_color='#000000')
+        renderer = SvgRenderer(self.can_draw_sharps_and_flats, highlight_color='#000000', is_dark_mode=is_dark_mode)
         try:
             page = renderer.svg_to_page(svg)
 
@@ -4186,9 +4186,12 @@ class MainFrame(wx.Frame):
         self.editor.SetMarginType(1,stc.STC_MARGIN_NUMBER)
 
         # 1.3.6.2 [JWdJ] 2015-02
-        self.renderer = SvgRenderer(self.settings['can_draw_sharps_and_flats'], self.settings.get('note_highlight_color', default_note_highlight_color), self.settings.get('note_highlight_follow_color', default_note_highlight_follow_color))#'#FF0000')
+        self.renderer = SvgRenderer(self.settings['can_draw_sharps_and_flats'], self.settings.get('note_highlight_color', default_note_highlight_color), self.settings.get('note_highlight_follow_color', default_note_highlight_follow_color), is_dark_mode=is_dark_mode)#'#FF0000')
         self.music_pane = MusicScorePanel(self, self.renderer)
-        self.music_pane.SetBackgroundColour((255, 255, 255))
+        if is_dark_mode:
+            self.music_pane.SetBackgroundColour(wx.Colour(30, 30, 30))
+        else:
+            self.music_pane.SetBackgroundColour((255, 255, 255))
         self.music_pane.OnNoteSelectionChangedDesc = self.OnNoteSelectionChangedDesc
 
         error_font_size = get_normal_fontsize() # 1.3.6.3 [JWDJ] one function to set font size

--- a/easy_abc.py
+++ b/easy_abc.py
@@ -213,6 +213,34 @@ default_style_color = {
     'style_ornamentexcl_color':'#015692'
 }
 
+# Dark mode color scheme (light colors for dark backgrounds)
+default_dark_style_color = {
+    'style_default_color':'#E0E0E0',
+    'style_chord_color':'#E0E0E0',
+    'style_comment_color':'#9DA5AD',
+    'style_specialcomment_color':'#D19ED1',
+    'style_bar_color':'#6699FF',
+    'style_field_color':'#FFB366',
+    'style_fieldvalue_color':'#FFB366',
+    'style_embeddedfield_color':'#FFB366',
+    'style_embeddedfieldvalue_color':'#FFB366',
+    'style_fieldindex_color':'#FFFFFF',
+    'style_string_color':'#7FBF8F',
+    'style_lyrics_color':'#8FBF8F',
+    'style_grace_color':'#CFAA7F',
+    'style_ornament_color':'#6EB5FF',
+    'style_ornamentplus_color':'#6EB5FF',
+    'style_ornamentexcl_color':'#6EB5FF'
+}
+
+is_dark_mode = None  # Initialized after wx.App creation
+
+def get_effective_style_color():
+    """Return the appropriate color scheme based on dark mode setting."""
+    if is_dark_mode:
+        return default_dark_style_color
+    return default_style_color
+
 control_margin = 6
 default_midi_volume = 96
 default_midi_pan = 64
@@ -8559,29 +8587,40 @@ class MainFrame(wx.Frame):
 
         editor.SetProperty("fold", "0")
         set_style = editor.StyleSetSpec
-        set_style(self.styler.STYLE_DEFAULT, "fore:%s,face:%s,size:%d" % (self.settings.get('style_default_color',default_style_color['style_default_color']), font, size))
-        set_style(self.styler.STYLE_CHORD, "fore:%s,face:%s,size:%d" % (self.settings.get('style_chord_color',default_style_color['style_chord_color']), font, size))
+
+        # Set editor background color based on dark mode
+        effective_colors = get_effective_style_color()
+        if is_dark_mode:
+            editor.StyleSetBackground(stc.STC_STYLE_DEFAULT, wx.Colour(30, 30, 30))
+            editor.SetCaretForeground(wx.Colour(255, 255, 255))
+        else:
+            editor.StyleSetBackground(stc.STC_STYLE_DEFAULT, wx.Colour(255, 255, 255))
+            editor.SetCaretForeground(wx.Colour(0, 0, 0))
+        editor.StyleClearAll()  # Propagate background to all styles
+
+        set_style(self.styler.STYLE_DEFAULT, "fore:%s,face:%s,size:%d" % (self.settings.get('style_default_color', effective_colors['style_default_color']), font, size))
+        set_style(self.styler.STYLE_CHORD, "fore:%s,face:%s,size:%d" % (self.settings.get('style_chord_color', effective_colors['style_chord_color']), font, size))
         # Comments
-        set_style(self.styler.STYLE_COMMENT_NORMAL, "fore:%s,face:%s,italic,size:%d" % (self.settings.get('style_comment_color',default_style_color['style_comment_color']), font, size))
-        set_style(self.styler.STYLE_COMMENT_SPECIAL, "fore:%s,face:%s,italic,size:%d" % (self.settings.get('style_specialcomment_color',default_style_color['style_specialcomment_color']), font, size))
+        set_style(self.styler.STYLE_COMMENT_NORMAL, "fore:%s,face:%s,italic,size:%d" % (self.settings.get('style_comment_color', effective_colors['style_comment_color']), font, size))
+        set_style(self.styler.STYLE_COMMENT_SPECIAL, "fore:%s,face:%s,italic,size:%d" % (self.settings.get('style_specialcomment_color', effective_colors['style_specialcomment_color']), font, size))
         # Bar
-        set_style(self.styler.STYLE_BAR, "fore:%s,face:%s,bold,size:%d" % (self.settings.get('style_bar_color',default_style_color['style_bar_color']), font, size))
+        set_style(self.styler.STYLE_BAR, "fore:%s,face:%s,bold,size:%d" % (self.settings.get('style_bar_color', effective_colors['style_bar_color']), font, size))
         # Field
-        set_style(self.styler.STYLE_FIELD,                "fore:%s,face:%s,bold,size:%d" % (self.settings.get('style_field_color',default_style_color['style_field_color']), font, size))
-        set_style(self.styler.STYLE_FIELD_VALUE,          "fore:%s,face:%s,italic,size:%d" % (self.settings.get('style_fieldvalue_color',default_style_color['style_fieldvalue_color']), font, size))
-        set_style(self.styler.STYLE_EMBEDDED_FIELD,       "fore:%s,face:%s,bold,size:%d" % (self.settings.get('style_embeddedfield_color',default_style_color['style_embeddedfield_color']), font, size))
-        set_style(self.styler.STYLE_EMBEDDED_FIELD_VALUE, "fore:%s,face:%s,italic,size:%d" % (self.settings.get('style_embeddedfieldvalue_color',default_style_color['style_embeddedfieldvalue_color']), font, size))
-        set_style(self.styler.STYLE_FIELD_INDEX,          "fore:%s,face:%s,bold,underline,size:%d" % (self.settings.get('style_fieldindex_color',default_style_color['style_fieldindex_color']), font, size))
+        set_style(self.styler.STYLE_FIELD,                "fore:%s,face:%s,bold,size:%d" % (self.settings.get('style_field_color', effective_colors['style_field_color']), font, size))
+        set_style(self.styler.STYLE_FIELD_VALUE,          "fore:%s,face:%s,italic,size:%d" % (self.settings.get('style_fieldvalue_color', effective_colors['style_fieldvalue_color']), font, size))
+        set_style(self.styler.STYLE_EMBEDDED_FIELD,       "fore:%s,face:%s,bold,size:%d" % (self.settings.get('style_embeddedfield_color', effective_colors['style_embeddedfield_color']), font, size))
+        set_style(self.styler.STYLE_EMBEDDED_FIELD_VALUE, "fore:%s,face:%s,italic,size:%d" % (self.settings.get('style_embeddedfieldvalue_color', effective_colors['style_embeddedfieldvalue_color']), font, size))
+        set_style(self.styler.STYLE_FIELD_INDEX,          "fore:%s,face:%s,bold,underline,size:%d" % (self.settings.get('style_fieldindex_color', effective_colors['style_fieldindex_color']), font, size))
         # Single quoted string
-        set_style(self.styler.STYLE_STRING, "fore:%s,face:%s,italic,size:%d" % (self.settings.get('style_string_color',default_style_color['style_string_color']), font, size))
+        set_style(self.styler.STYLE_STRING, "fore:%s,face:%s,italic,size:%d" % (self.settings.get('style_string_color', effective_colors['style_string_color']), font, size))
         # Lyrics
-        set_style(self.styler.STYLE_LYRICS, "fore:%s,face:%s,italic,size:%d" % (self.settings.get('style_lyrics_color',default_style_color['style_lyrics_color']), font, size))
+        set_style(self.styler.STYLE_LYRICS, "fore:%s,face:%s,italic,size:%d" % (self.settings.get('style_lyrics_color', effective_colors['style_lyrics_color']), font, size))
 
-        set_style(self.styler.STYLE_GRACE, "fore:%s,face:%s,italic,size:%d" % (self.settings.get('style_grace_color',default_style_color['style_grace_color']), font, size))
+        set_style(self.styler.STYLE_GRACE, "fore:%s,face:%s,italic,size:%d" % (self.settings.get('style_grace_color', effective_colors['style_grace_color']), font, size))
 
-        set_style(self.styler.STYLE_ORNAMENT, "fore:%s,face:%s,bold,size:%d" % (self.settings.get('style_ornament_color',default_style_color['style_ornament_color']), font, size))
-        set_style(self.styler.STYLE_ORNAMENT_PLUS, "fore:%s,face:%s,size:%d" % (self.settings.get('style_ornamentplus_color',default_style_color['style_ornamentplus_color']), font, size))
-        set_style(self.styler.STYLE_ORNAMENT_EXCL, "fore:%s,face:%s,size:%d" % (self.settings.get('style_ornamentexcl_color',default_style_color['style_ornamentexcl_color']), font, size))
+        set_style(self.styler.STYLE_ORNAMENT, "fore:%s,face:%s,bold,size:%d" % (self.settings.get('style_ornament_color', effective_colors['style_ornament_color']), font, size))
+        set_style(self.styler.STYLE_ORNAMENT_PLUS, "fore:%s,face:%s,size:%d" % (self.settings.get('style_ornamentplus_color', effective_colors['style_ornamentplus_color']), font, size))
+        set_style(self.styler.STYLE_ORNAMENT_EXCL, "fore:%s,face:%s,size:%d" % (self.settings.get('style_ornamentexcl_color', effective_colors['style_ornamentexcl_color']), font, size))
 
         editor.SetModEventMask(wx.stc.STC_MODEVENTMASKALL & ~(wx.stc.STC_MOD_CHANGESTYLE | wx.stc.STC_PERFORMED_USER)) # [1.3.7.4] JWDJ: don't fire OnModified on style changes
         editor.Colourise(0, editor.GetLength())
@@ -9340,7 +9379,15 @@ class MyApp(wx.App):
             self.frame.load_or_import(path)
 
     def OnInit(self):
+        global is_dark_mode, dialog_background_colour
         try:
+            # Detect dark mode early (wxPython 4.1+)
+            try:
+                is_dark_mode = wx.SystemSettings.GetAppearance().IsDark()
+            except AttributeError:
+                is_dark_mode = False
+            dialog_background_colour = wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW)
+
             self.SetAppName('EasyABC')
             #wx.SystemOptions.SetOptionInt('msw.window.no-clip-children', 1)
             app_dir = self.app_dir = wx.StandardPaths.Get().GetUserLocalDataDir()
@@ -9400,7 +9447,6 @@ class MyApp(wx.App):
         return True
 
 app = MyApp(0)
-dialog_background_colour = wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW)
 
 #import wx.lib.inspection
 #wx.lib.inspection.InspectionTool().Show()

--- a/easy_abc.py
+++ b/easy_abc.py
@@ -172,7 +172,7 @@ class NWCConversionException(Exception): pass
 
 from abc_tune import *
 
-dialog_background_colour = wx.Colour(245, 244, 235)
+dialog_background_colour = None  # Initialized after wx.App creation
 default_note_highlight_color = '#FF7F3F'
 default_note_highlight_follow_color = '#CC00FF'
 #default_style_color = {
@@ -9400,6 +9400,7 @@ class MyApp(wx.App):
         return True
 
 app = MyApp(0)
+dialog_background_colour = wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW)
 
 #import wx.lib.inspection
 #wx.lib.inspection.InspectionTool().Show()

--- a/easy_abc.py
+++ b/easy_abc.py
@@ -4203,7 +4203,7 @@ class MainFrame(wx.Frame):
 
         # 1.3.6.3 [JWdJ] 2015-04-21 ABC Assist added
         from abc_assist_panel import AbcAssistPanel  # 1.3.7.1 [JWDJ] 2016-1 because of translation this import has to be done as late as possible
-        self.abc_assist_panel = AbcAssistPanel(self, self.editor, cwd, self.settings)
+        self.abc_assist_panel = AbcAssistPanel(self, self.editor, cwd, self.settings, is_dark_mode=is_dark_mode)
         self.assist_pane = aui.AuiPaneInfo().Name("abcassist").CaptionVisible(True).Caption(_("ABC assist")).\
             CloseButton(True).MinimizeButton(False).MaximizeButton(False).\
             Left().Layer(1).Position(1).BestSize(300, 600) # .PaneBorder(False) # Fixed()

--- a/music_score_panel.py
+++ b/music_score_panel.py
@@ -222,7 +222,7 @@ class MusicScorePanel(wx.ScrolledWindow):
             if self.highlighted_notes:
                 self.renderer.draw_notes(page=self.current_page, note_indices=self.highlighted_notes, highlight=True, dc=dc, highlight_follow=self.highlight_follow)
         else:
-            dc.SetBackground(wx.WHITE_BRUSH)
+            dc.SetBackground(self.renderer.get_background_brush())
             dc.Clear()
 
     def set_page(self, page):
@@ -295,7 +295,7 @@ class MusicScorePanel(wx.ScrolledWindow):
         if not WX4:
             dc.BeginDrawing()
         try:
-            dc.SetBackground(wx.WHITE_BRUSH)
+            dc.SetBackground(self.renderer.get_background_brush())
             dc.Clear()
             self.draw_drag_rect(dc)
             if self.current_page != self.renderer.empty_page:


### PR DESCRIPTION
It's impossible for me to use EasyABC (recent version) on dark mode.

I am pushing this fix to use system window color instead of hardcoded light beige, so dialogs are readable in both light and dark mode.